### PR TITLE
Remove use of properties to report memory/stack errors LONG AFTER 1.6.7

### DIFF
--- a/argparser.cpp
+++ b/argparser.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <memory>
 #include <string>
+#include <limits>
 #include "utilsfuncs.h"
 #include "argparser.h"
 #include "argnames.h"

--- a/argparser.cpp
+++ b/argparser.cpp
@@ -465,8 +465,6 @@ void ArgParser::setupMaxHeapAndStack(list<string> userOptions) {
     if (!maxStack) {
         javaOptions.push_back("-Xss" + stackSize);
     }
-    javaOptions.push_back("-Djruby.memory.max=" + heapSize);
-    javaOptions.push_back("-Djruby.stack.max=" + stackSize);
 }
 
 void ArgParser::constructBootClassPath() {


### PR DESCRIPTION
As of JRuby 1.6.7, we will use RuntimeMXBean to report any -Xmx
and -Xss values passed to Java, rather than relying on a JRuby-
specific property. This change removes setting this property from
jruby-launcher.

NOTE: This change should NOT be incorporated into a jruby-launcher
release until long after 1.6.7 has been out, since previous
releases still rely on the property being set to report memory
and stack errors.