### PR TITLE
strlcpy is a macro under OS X 10.9

### DIFF
--- a/strlcpy.c
+++ b/strlcpy.c
@@ -34,6 +34,9 @@ static char *rcsid = "$OpenBSD: strlcpy.c,v 1.5 2001/05/13 15:40:16 deraadt Exp 
 #include <sys/types.h>
 #include <string.h>
 
+#ifdef strlcpy
+#undef strlcpy
+#endif
 /*
  * Copy src to string dst of size siz.  At most siz-1 characters
  * will be copied.  Always NUL terminates (unless siz == 0).


### PR DESCRIPTION
A quick change to get things to build on Mavericks. `make test` passed
