### PR TITLE
Avoid segfault when arguments contain format strings

### DIFF
--- a/spec/launcher_spec.rb
+++ b/spec/launcher_spec.rb
@@ -255,4 +255,8 @@ describe "JRuby native launcher" do
   it "should print the version" do
     jruby_launcher("-Xversion 2>&1").should =~ /Launcher Version #{JRubyLauncher::VERSION}/
   end
+
+  it "should not crash on format-strings" do
+    jruby_launcher_args("-e %s%s%s%s%s 2>&1").should include('-e', '%s%s%s%s%s')
+  end
 end

--- a/unixlauncher.cpp
+++ b/unixlauncher.cpp
@@ -71,7 +71,7 @@ int UnixLauncher::run(int argc, char* argv[], char* envp[]) {
 
     logMsg("Command line:");
     for (list<string>::iterator it = commandLine.begin(); it != commandLine.end(); ++it) {
-        logMsg(it->c_str());
+        logMsg("\t%s", it->c_str());
     }
 
     char** newArgv = convertToArgvArray(commandLine);


### PR DESCRIPTION
This also adds a tab to the start of the lines, since for example parsed arguments are printed this way.

This issue seems to have been reported in JRuby before (see https://github.com/jruby/jruby/issues/1689), but it was closed as the segfault doesn't happen consistently unless you use "a lot" of formatting codes.