### PR TITLE
Set C++ standard explicitly to C++ 98

### DIFF
--- a/inc/Makefile-conf.mk
+++ b/inc/Makefile-conf.mk
@@ -4,8 +4,8 @@ CP=cp
 CCADMIN=CCadmin
 RANLIB=ranlib
 CC=gcc
-CCC=g++
-CXX=g++
+CCC=g++ --std=c++98
+CXX=g++ --std=c++98
 
 # Windows (mingw)?
 ifneq (,$(findstring mingw, $(CONF)))


### PR DESCRIPTION
Fixes [issue #13](https://github.com/jruby/jruby-launcher/issues/13). I would have preferred to also change `g++` to `c++` and `gcc` to `cc` (this would allow the installation to work using Clang on FreeBSD 11 (where gcc is not installed by default and `g++` and `gcc` are not defined as aliases)) but I wanted a minimal fix and was worried that it [might cause problems on other platforms](https://stackoverflow.com/a/1516658).