### PR TITLE
fix initialisation of argparser - fixes #16

### DIFF
--- a/argparser.cpp
+++ b/argparser.cpp
@@ -75,6 +75,7 @@ ArgParser::ArgParser()
     , nailgunClient(false)
     , noBootClassPath(false)
     , printCommandLine(false)
+    , useModulePath(false)
 {
 }
 


### PR DESCRIPTION
This PR fixes issue #16 - the `useModulePath` boolean was not correctly initialised.