### PR TITLE
Fix incorrect usage of NULL as a end-of-string in argparser.cpp

### DIFF
--- a/argparser.cpp
+++ b/argparser.cpp
@@ -135,7 +135,7 @@ bool ArgParser::initPlatformDir() {
 
     if (getenv("JRUBY_HOME") != NULL) {
         logMsg("initPlatformDir: using JRUBY_HOME environment variable");
-        char sep[2] = { FILE_SEP, NULL };
+        char sep[2] = { FILE_SEP, '\0' };
         strncpy(path, getenv("JRUBY_HOME"), PATH_MAX - 11);
         strncpy(path + strlen(path), sep, 1);
         strncpy(path + strlen(path), "bin", 3);


### PR DESCRIPTION
Fix incorrect usage of NULL as a end-of-string in argparser.cpp