### PR TITLE
Add script/build, Dockerfile.build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.dll
 *.exe
 *~
-build
+/build
 nbproject/private/private.xml
 jruby.res
 /jruby

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,4 @@
+FROM ubuntu
+RUN mkdir -p /build
+RUN apt update && apt install --no-install-recommends -y build-essential
+WORKDIR /build

--- a/script/build
+++ b/script/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+[[ "$DEBUG" ]] && set -x
+set -e 
+
+rm -rf build/unix
+docker build -t jruby/build -f Dockerfile.build .
+docker run --rm --volume=$PWD:/build -it jruby/build make
+docker image rm jruby/build
+
+# If the user is on MacOS, go ahead and build MacOS too.
+if which uname 1>/dev/null 2>&1 && [[ "$(uname -s)" == "Darwin" ]]; then
+  printf "\n\n\n\n\n"
+  
+  if ! which make 1>/dev/null 2>&1; then
+    echo "Unable to find dev tools"
+    echo "Try running \`xcode-select --install\`"
+    exit 1
+  fi
+  
+  make
+fi


### PR DESCRIPTION
This adds Dockerfile.build, and script/build.  This will build on Linux in Docker, and if on macOS it will also build the Darwin version, otherwise it will just let you be with the Linux version.