### PR TITLE
Older versions of JRuby do not load RbConfig by default

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -1,3 +1,4 @@
+require 'rbconfig'
 mf = File.read('Makefile')
 mf = mf.gsub(/^BINDIR\s*=.*$/, "BINDIR = #{RbConfig::CONFIG['bindir']}")
 mf = mf.gsub(/^PREFIX\s*=.*$/, "PREFIX = #{File.dirname(RbConfig::CONFIG['libdir'])}")


### PR DESCRIPTION
As a result of rbenv/ruby-build#1293 we discovered a build issue for jruby-launcher.

JRuby 1.6.8, for example, fails 'gem install jruby-launcher'. 
```
  /home/deploy/.rbenv/versions/jruby-1.6.8/bin/jruby extconf.rb
  NameError: uninitialized constant RbConfig
```

In fact most elderly JRuby's are making the same complaint. This quick patch would make a lot of retro JRuby'ers happier.