### PR TITLE
Fix java.lang.IllegalCallerException: sun.nio.ch is not open to module org.jruby.dist

### DIFF
--- a/argparser.cpp
+++ b/argparser.cpp
@@ -247,12 +247,6 @@ bool ArgParser::parseArgs(int argc, char *argv[]) {
     }
 #endif
 
-    javaOptions.push_back("--add-opens");
-    javaOptions.push_back("java.base/java.io=org.jruby.dist");
-    javaOptions.push_back("--add-opens");
-    javaOptions.push_back("java.base/java.nio.channels=org.jruby.dist");
-    javaOptions.push_back("--add-opens");
-    javaOptions.push_back("java.base/sun.nio.ch=org.jruby.dist");
 
     // Force OpenJDK-based JVMs to use /dev/urandom for random number generation
     // See https://github.com/jruby/jruby/issues/4685 among others.
@@ -497,6 +491,13 @@ void ArgParser::prepareOptions() {
         option = OPT_CMDLINE_MODULE_PATH;
         option += classPath;
         javaOptions.push_back(option);
+
+        javaOptions.push_back("--add-opens");
+        javaOptions.push_back("java.base/java.io=org.jruby.dist");
+        javaOptions.push_back("--add-opens");
+        javaOptions.push_back("java.base/java.nio.channels=org.jruby.dist");
+        javaOptions.push_back("--add-opens");
+        javaOptions.push_back("java.base/sun.nio.ch=org.jruby.dist");
     } else if (separateProcess) {
         // When launching a separate process, use '-cp' which expands embedded wildcards
         javaOptions.push_back(OPT_CMDLINE_CLASS_PATH);

--- a/argparser.cpp
+++ b/argparser.cpp
@@ -247,6 +247,13 @@ bool ArgParser::parseArgs(int argc, char *argv[]) {
     }
 #endif
 
+    javaOptions.push_back("--add-opens");
+    javaOptions.push_back("java.base/java.io=org.jruby.dist");
+    javaOptions.push_back("--add-opens");
+    javaOptions.push_back("java.base/java.nio.channels=org.jruby.dist");
+    javaOptions.push_back("--add-opens");
+    javaOptions.push_back("java.base/sun.nio.ch=org.jruby.dist");
+
     // Force OpenJDK-based JVMs to use /dev/urandom for random number generation
     // See https://github.com/jruby/jruby/issues/4685 among others.
     struct stat buffer;


### PR DESCRIPTION
This fixes issues when using JRuby 9.2.7.0 with Java 11 on OpenBSD, using the same `--add-opens` options that `jruby.bash` uses.