### PR TITLE
`rubyforge_project` was removed from rubygems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,6 @@ task :gemspec => './lib/jruby-launcher.rb' do
     s.extensions = ["extconf.rb"]
     s.files = FileList["COPYING", "README.md", "Makefile", "Rakefile", "*.c", "*.cpp", "*.h", "inc/*.*", "**/*.rb", "resources/*.*"]
     s.homepage = %q{http://jruby.org}
-    s.rubyforge_project = %q{jruby-extras}
   end
 end
 


### PR DESCRIPTION
See rubygems/rubygems#2436 and rubygems/rubygems#2798.