### PR TITLE
Handle add-options appropriately across JRuby versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # These line gets substituted with the actual Config::CONFIG items location by extconf.rb
 PREFIX = notspecified
 BINDIR = $(PREFIX)/bin
+JRUBY_VERSION = notspecified
+JRUBY_MODULE =
 INSTALLDIR = $(PREFIX)/lib/ruby/shared/rubygems/defaults
 INSTALLDIR9000 = $(PREFIX)/lib/ruby/stdlib/rubygems/defaults
 OLDINSTALLDIR = $(PREFIX)/lib/ruby/site_ruby/1.8/rubygems/defaults

--- a/argparser.cpp
+++ b/argparser.cpp
@@ -498,12 +498,25 @@ void ArgParser::prepareOptions() {
     }
 
     if (useModulePath) {
-        javaOptions.push_back("--add-opens");
-        javaOptions.push_back("java.base/java.io=org.jruby.dist");
-        javaOptions.push_back("--add-opens");
-        javaOptions.push_back("java.base/java.nio.channels=org.jruby.dist");
-        javaOptions.push_back("--add-opens");
-        javaOptions.push_back("java.base/sun.nio.ch=org.jruby.dist");
+        string moduleOptsFile = platformDir + "/bin/.jruby.module_opts";
+        if (access(moduleOptsFile.c_str(), R_OK) == 0) {
+            logMsg("using @arguments file for Java module options");
+            javaOptions.push_back(string("@") + platformDir + "/bin/.jruby.module_opts");
+        } else {
+            // If .module_opts file is not detected, only add options if JRUBY_MODULE is defined.
+            // See extconf.rb for rules on which JRuby versions get JRUBY_MODULE.
+#ifdef JRUBY_MODULE
+            logMsg("using hardcoded module options");
+            javaOptions.push_back("--add-opens");
+            javaOptions.push_back("java.base/java.io=org.jruby.dist");
+            javaOptions.push_back("--add-opens");
+            javaOptions.push_back("java.base/java.nio.channels=org.jruby.dist");
+            javaOptions.push_back("--add-opens");
+            javaOptions.push_back("java.base/sun.nio.ch=org.jruby.dist");
+#else
+            logMsg("no JRuby module support detected, skipping module flags")
+#endif
+        }
     }
 
     if (separateProcess) {

--- a/extconf.rb
+++ b/extconf.rb
@@ -1,5 +1,13 @@
 mf = File.read('Makefile')
 mf = mf.gsub(/^BINDIR\s*=.*$/, "BINDIR = #{RbConfig::CONFIG['bindir']}")
 mf = mf.gsub(/^PREFIX\s*=.*$/, "PREFIX = #{File.dirname(RbConfig::CONFIG['libdir'])}")
+mf = mf.gsub(/^JRUBY_VERSION\s*=.*$/, "JRUBY_VERSION = #{JRUBY_VERSION}")
+
+# Launcher will use .module_opts file if present, otherwise hardcoded add-opens for this module.
+# Pre-9.2.1: ALL-UNNAMED because no name was exported
+# 9.2.1 and higher: org.jruby.dist
+if JRUBY_VERSION !~ /(^1)|(9\.[01])|(9.2.0.0)/
+  mf = mf.gsub(/^JRUBY_MODULE\s*=.*$/, "JRUBY_MODULE = 1")
+end
 puts mf
 File.open('Makefile', 'wb') {|f| f << mf}

--- a/inc/Makefile-conf.mk
+++ b/inc/Makefile-conf.mk
@@ -71,3 +71,6 @@ ifneq (,$(findstring SunOS,$(CND_PLATFORM)))
 CFLAGS += -D__SUNOS__
 LDLIBSOPTIONS += -lsocket -lnsl
 endif
+
+# define JRUBY_MODULE appropriately for target JRuby
+CFLAGS += -DJRUBY_MODULE=${JRUBY_MODULE}


### PR DESCRIPTION
For JRuby versions earlier than 9.2.1, we do not specify add-opens
flags because we do not export a module to use.

For JRuby versions from 9.2.1 through 9.2.9, we hardcode some
add-opens for org.jruby.dist, because these versions did not ship
a .module_opts file.

For JRuby versions 9.2.10 and higher we use .module_opts file.