### PR TITLE
Fixes #40 (v1.1.18 no longer builds on CentOS/RHEL/Oracle Linux 7)

### DIFF
--- a/unixlauncher.cpp
+++ b/unixlauncher.cpp
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <limits.h>


### PR DESCRIPTION
Missing `<stdio.h>` include in `unixlauncher.cpp`:

Before:
```shell
$ make
make -f inc/Makefile-rules.mk CONF=unix SUBPROJECTS= .build-conf
make[1]: Entering directory `/home/ec2-user/jruby-launcher'
make -f inc/Makefile-rules.mk jruby
make[2]: Entering directory `/home/ec2-user/jruby-launcher'
mkdir -p build/unix/Linux
rm -f build/unix/Linux/argparser.o.d
g++ -O2 -Wall  -DJRUBY_MODULE=1   -c argparser.cpp -MMD -MP -MF build/unix/Linux/argparser.o.d -o build/unix/Linux/argparser.o
mkdir -p build/unix/Linux
rm -f build/unix/Linux/utilsfuncs.o.d
g++ -O2 -Wall  -DJRUBY_MODULE=1   -c utilsfuncs.cpp -MMD -MP -MF build/unix/Linux/utilsfuncs.o.d -o build/unix/Linux/utilsfuncs.o
mkdir -p build/unix/Linux
rm -f build/unix/Linux/ng.o.d
cc -O2 -Wall  -DJRUBY_MODULE=1   -c ng.c -MMD -MP -MF build/unix/Linux/ng.o.d -o build/unix/Linux/ng.o
mkdir -p build/unix/Linux
rm -f build/unix/Linux/strlcpy.o.d
cc -O2 -Wall  -DJRUBY_MODULE=1   -c strlcpy.c -MMD -MP -MF build/unix/Linux/strlcpy.o.d -o build/unix/Linux/strlcpy.o
mkdir -p build/unix/Linux
rm -f build/unix/Linux/jrubyexe.o.d
g++ -O2 -Wall  -DJRUBY_MODULE=1   -c jrubyexe.cpp -MMD -MP -MF build/unix/Linux/jrubyexe.o.d -o build/unix/Linux/jrubyexe.o
mkdir -p build/unix/Linux
rm -f build/unix/Linux/unixlauncher.o.d
g++ -O2 -Wall  -DJRUBY_MODULE=1   -c unixlauncher.cpp -MMD -MP -MF build/unix/Linux/unixlauncher.o.d -o build/unix/Linux/unixlauncher.o
unixlauncher.cpp: In member function ‘int UnixLauncher::run(int, char**, char**)’:
unixlauncher.cpp:51:40: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if (java.find_last_of('/') == -1) {
                                        ^
unixlauncher.cpp:80:44: error: ‘popen’ was not declared in this scope
             fp = popen(javaHomeCommand, "r");
                                            ^
unixlauncher.cpp:82:43: error: ‘fgets’ was not declared in this scope
                 fgets(tmp, sizeof(tmp), fp);
                                           ^
unixlauncher.cpp:85:26: error: ‘pclose’ was not declared in this scope
                 pclose(fp);
                          ^
make[2]: *** [build/unix/Linux/unixlauncher.o] Error 1
make[2]: Leaving directory `/home/ec2-user/jruby-launcher'
make[1]: *** [.build-conf] Error 2
make[1]: Leaving directory `/home/ec2-user/jruby-launcher'
make: *** [.build-impl] Error 2
```

After:
```shell
$ make
make -f inc/Makefile-rules.mk CONF=unix SUBPROJECTS= .build-conf
make[1]: Entering directory `/home/ec2-user/jruby-launcher'
make -f inc/Makefile-rules.mk jruby
make[2]: Entering directory `/home/ec2-user/jruby-launcher'
mkdir -p build/unix/Linux
rm -f build/unix/Linux/argparser.o.d
g++ -O2 -Wall  -DJRUBY_MODULE=1   -c argparser.cpp -MMD -MP -MF build/unix/Linux/argparser.o.d -o build/unix/Linux/argparser.o
mkdir -p build/unix/Linux
rm -f build/unix/Linux/utilsfuncs.o.d
g++ -O2 -Wall  -DJRUBY_MODULE=1   -c utilsfuncs.cpp -MMD -MP -MF build/unix/Linux/utilsfuncs.o.d -o build/unix/Linux/utilsfuncs.o
mkdir -p build/unix/Linux
rm -f build/unix/Linux/ng.o.d
cc -O2 -Wall  -DJRUBY_MODULE=1   -c ng.c -MMD -MP -MF build/unix/Linux/ng.o.d -o build/unix/Linux/ng.o
mkdir -p build/unix/Linux
rm -f build/unix/Linux/strlcpy.o.d
cc -O2 -Wall  -DJRUBY_MODULE=1   -c strlcpy.c -MMD -MP -MF build/unix/Linux/strlcpy.o.d -o build/unix/Linux/strlcpy.o
mkdir -p build/unix/Linux
rm -f build/unix/Linux/jrubyexe.o.d
g++ -O2 -Wall  -DJRUBY_MODULE=1   -c jrubyexe.cpp -MMD -MP -MF build/unix/Linux/jrubyexe.o.d -o build/unix/Linux/jrubyexe.o
mkdir -p build/unix/Linux
rm -f build/unix/Linux/unixlauncher.o.d
g++ -O2 -Wall  -DJRUBY_MODULE=1   -c unixlauncher.cpp -MMD -MP -MF build/unix/Linux/unixlauncher.o.d -o build/unix/Linux/unixlauncher.o
unixlauncher.cpp: In member function ‘int UnixLauncher::run(int, char**, char**)’:
unixlauncher.cpp:52:40: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if (java.find_last_of('/') == -1) {
                                        ^
g++ -O2 -Wall  -DJRUBY_MODULE=1    -o build/unix/Linux/jruby-launcher build/unix/Linux/argparser.o build/unix/Linux/utilsfuncs.o build/unix/Linux/ng.o build/unix/Linux/strlcpy.o build/unix/Linux/jrubyexe.o build/unix/Linux/unixlauncher.o -lstdc++
cp build/unix/Linux/jruby-launcher jruby
make[2]: Leaving directory `/home/ec2-user/jruby-launcher'
make[1]: Leaving directory `/home/ec2-user/jruby-launcher'
```