### PR TITLE
unixlauncher.c: Fix bounds check in which

### DIFF
--- a/unixlauncher.c
+++ b/unixlauncher.c
@@ -31,8 +31,7 @@ static char *which(const char *const executable) {
     dirs[dirs_length] = ':';
 
     size_t dir_head = 0;
-    size_t i = 0;
-    do {
+    for (size_t i = 0; i <= dirs_length; i++) {
         if (dirs[i] == ':') {
             // Declare convenient path variables
             char *const dir = dirs + dir_head;
@@ -59,7 +58,7 @@ static char *which(const char *const executable) {
 
             dir_head = i + 1;
         }
-    } while (dirs[i++]);
+    };
 
     // Lookup has failed, free if necessary and return NULL
     if (exe_path != NULL) {


### PR DESCRIPTION
Found an incorrect bounds check in the Unix launcher wrapper, which caused it to try searching for paths in the following environment variable or invalid memory